### PR TITLE
[Feat] #5 quiz 채점 (ocr 사용) 메소드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	implementation 'com.google.cloud:google-cloud-vision:2.0.17'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter-vision:1.2.8.RELEASE'
+	implementation platform('com.google.cloud:libraries-bom:26.1.4')
+	implementation 'com.google.cloud:google-cloud-translate'
 }
 
 tasks.named('test') {

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
@@ -40,8 +40,8 @@ public class QuizController {
 
     // 문제 채점
 
-    // 클라이언트에서 인물id, 문제 정답(인포 키), 이미지 주소를 넘겨주면 서버에서 맞는지 여부만 알려줌.
-    // 클라이언트는 이미 인물 사진, 인물 이름, 문제 정답 가지고 있으므로 서버는 정답 여부만 리턴해주면 됨.
+    // 클라이언트에서 문제 정답(인포 키), 이미지 주소를 넘겨주면 서버에서 맞는지 여부만 알려줌.
+    // 클라이언트는 이미 인물 사진, 인물 이름, 문제 정답 가지고 있으므로 서버는 정답 여부만 Boolean으로 리턴해주면 됨.
     @PostMapping(value = "/scoring")
     // @requestbody 사용 시 formdata 오류. multidataForm 으로 넣으려면 어노테이션 빼야 함.
     public BaseResponse<Boolean> scoring(@RequestBody ScoreReqDto dto) throws IOException {

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
@@ -2,10 +2,13 @@ package gdsc.mju.guessme.domain.quiz;
 
 import gdsc.mju.guessme.domain.quiz.dto.CreateQuizResDto;
 import gdsc.mju.guessme.domain.quiz.dto.NewScoreDto;
+import gdsc.mju.guessme.domain.quiz.dto.ScoreReqDto;
 import gdsc.mju.guessme.global.response.BaseException;
 import gdsc.mju.guessme.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +35,21 @@ public class QuizController {
                 200,
                 "Load Successfully",
                 quizService.newscore(newScoreDto)
+        );
+    }
+
+    // 문제 채점
+
+    // 클라이언트에서 인물id, 문제 정답(인포 키), 이미지 주소를 넘겨주면 서버에서 맞는지 여부만 알려줌.
+    // 클라이언트는 이미 인물 사진, 인물 이름, 문제 정답 가지고 있으므로 서버는 정답 여부만 리턴해주면 됨.
+    @PostMapping(value = "/scoring")
+    // @requestbody 사용 시 formdata 오류. multidataForm 으로 넣으려면 어노테이션 빼야 함.
+    public BaseResponse<Boolean> scoring(@RequestBody ScoreReqDto dto) throws IOException {
+        // dto에 인물id, 인포키, 파일 주소 넣어서 전달
+        return new BaseResponse<>(
+                200,
+                "Load Successfully",
+                quizService.scoring(dto)
         );
     }
 }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/QuizService.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/QuizService.java
@@ -1,15 +1,21 @@
 package gdsc.mju.guessme.domain.quiz;
 
+import com.google.cloud.vision.v1.*;
+import com.google.protobuf.ByteString;
 import gdsc.mju.guessme.domain.info.dto.InfoObj;
 import gdsc.mju.guessme.domain.info.repository.InfoRepository;
 import gdsc.mju.guessme.domain.person.entity.Person;
 import gdsc.mju.guessme.domain.person.repository.PersonRepository;
 import gdsc.mju.guessme.domain.quiz.dto.CreateQuizResDto;
 import gdsc.mju.guessme.domain.quiz.dto.NewScoreDto;
+import gdsc.mju.guessme.domain.quiz.dto.ScoreReqDto;
 import gdsc.mju.guessme.domain.user.entity.User;
 import gdsc.mju.guessme.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
@@ -57,5 +63,85 @@ public class QuizService {
 
         personRepository.updateScore(newScoreDto.getPersonId(), newScoreDto.getScore());
         return newScoreDto.getScore();
+    }
+
+    // 이미지에서 텍스트 추출
+    public String detectText(String filePath) throws IOException {
+
+        List<AnnotateImageRequest> requests = new ArrayList<>();
+
+        ByteString imgBytes = ByteString.readFrom(new FileInputStream(filePath));
+
+        Image img = Image.newBuilder().setContent(imgBytes).build();
+        Feature feat = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build();
+        AnnotateImageRequest request =
+                AnnotateImageRequest.newBuilder().addFeatures(feat).setImage(img).build();
+        requests.add(request);
+
+        // Initialize client that will be used to send requests. This client only needs to be created
+        // once, and can be reused for multiple requests. After completing all of your requests, call
+        // the "close" method on the client to safely clean up any remaining background resources.
+        try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
+            BatchAnnotateImagesResponse response = client.batchAnnotateImages(requests);
+            List<AnnotateImageResponse> responses = response.getResponsesList();
+
+            for (AnnotateImageResponse res : responses) {
+                if (res.hasError()) {
+                    System.out.format("Error: %s%n", res.getError().getMessage());
+                    return null;
+                }
+
+                // For full list of available annotations, see http://g.co/cloud/vision/docs
+                for (EntityAnnotation annotation : res.getTextAnnotationsList()) {
+                    return annotation.getDescription();
+                }
+            }
+            return null;
+        }
+    }
+
+    public Boolean scoring(ScoreReqDto dto) throws IOException {
+
+        String infoValue = dto.getInfoValue(); // 클라에서 갖고 있는 정답
+
+        String filePath = dto.getFilePath();
+
+        String textFromImage = detectText(filePath); // 이미지 추출 텍스트
+        System.out.println("textFromImage = " + textFromImage);
+
+        // 한글로만 입력 받는다고 가정, 두 글자 이상 연속으로 중복되는 경우 정답 처리
+        String overlap = findOverlap(infoValue, textFromImage);
+
+        if (overlap != null) {
+            System.out.println("겹치는 단어: " + overlap);
+            return Boolean.TRUE;
+        } else {
+            System.out.println("겹치는 단어가 없습니다.");
+            return Boolean.FALSE;
+        }
+    }
+
+    public String findOverlap(String str1, String str2) {
+        // 더 긴 문자열 str1로 설정
+        if (str1.length() < str2.length()) {
+            String temp = str1;
+            str1 = str2;
+            str2 = temp;
+        }
+
+        // 더 긴 문자열을 기준으로 루프를 돌면서 서브스트링을 만들어 비교
+        for (int i = str2.length(); i > 0; i--) {
+            for (int j = 0; j <= str2.length() - i; j++) {
+                if (str1.contains(str2.substring(j, j + i))) {
+                    String ans = str2.substring(j, j + i);
+                    if (ans.length() >= 2) {
+                        return ans;
+                    }
+                    return null;
+                }
+            }
+        }
+
+        return null; // 겹치는 단어가 없을 경우 null 반환
     }
 }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/dto/ScoreReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/dto/ScoreReqDto.java
@@ -1,0 +1,14 @@
+package gdsc.mju.guessme.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ScoreReqDto {
+    private String infoValue;
+    private String answer; // 사진
+    private String filePath; // 이미지 파일 경로
+}


### PR DESCRIPTION
Feat/#5 Quiz 도메인 API 구현 완료

- [x] /create/{id} 메서드 구현 완료
- [x] /newscore 메서드 구현 완료
- [x]  /scoring 메서드 구현 완료

**문제 채점 방식**

클라이언트에서 문제 정답(인포 키), 이미지 주소를 넘겨주면 서버에서 맞는지 여부 알려줌.
클라이언트는 이미 인물 사진, 인물 이름, 문제 정답 가지고 있으므로 서버는 정답 여부만 리턴해주면 됨.

close #5, close #19