### PR TITLE
[Feat] #18 Request body의 property에 필요에 따라 null을 실을 수 있도록 함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .prod.env
 .test.env
 
+# credential file
+*.json
+
 # Querydsl
 /src/main/generated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11
+
+ARG JAR_FILE=./build/libs/guessme-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+# env
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/java/gdsc/mju/guessme/domain/person/PersonController.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/PersonController.java
@@ -42,6 +42,7 @@ public class PersonController {
     public BaseResponse<Void> createPerson(
         @RequestBody CreatePersonReqDto createPersonReqDto
     ) throws BaseException {
+        System.out.println(createPersonReqDto.toString());
         personService.createPerson(createPersonReqDto);
         return new BaseResponse<>(
             201,

--- a/src/main/java/gdsc/mju/guessme/domain/person/PersonService.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/PersonService.java
@@ -14,6 +14,7 @@ import gdsc.mju.guessme.domain.user.entity.User;
 import gdsc.mju.guessme.domain.user.repository.UserRepository;
 import gdsc.mju.guessme.global.response.BaseException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -37,19 +38,21 @@ public class PersonService {
 
     public void createPerson(CreatePersonReqDto createPersonReqDto) throws BaseException {
         // TODO: use test user now but need to use user from token
-         User user = userRepository.findByUserId("test");
-         if(user == null) {
-             throw new BaseException(404, "User not found");
-         }
+        User user = userRepository.findByUserId("test");
+        if (user == null) {
+            throw new BaseException(404, "User not found");
+        }
 
         // TODO: image upload to gcs
 
         // TODO: voice upload to gcs
 
         // Person 저장
+        Optional<String> image = createPersonReqDto.getImage();
+        Optional<String> voice = createPersonReqDto.getVoice();
         personRepository.save(Person.builder()
-            .image(createPersonReqDto.getImage())
-            .voice(createPersonReqDto.getVoice())
+            .image(image.orElse(null))
+            .voice(voice.orElse(null))
             .name(createPersonReqDto.getName())
             .relation(createPersonReqDto.getRelation())
             .birth(createPersonReqDto.getBirth())

--- a/src/main/java/gdsc/mju/guessme/domain/person/PersonService.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/PersonService.java
@@ -48,11 +48,11 @@ public class PersonService {
         // TODO: voice upload to gcs
 
         // Person 저장
-        Optional<String> image = createPersonReqDto.getImage();
-        Optional<String> voice = createPersonReqDto.getVoice();
+        String image = createPersonReqDto.getImage();
+        String voice = createPersonReqDto.getVoice();
         personRepository.save(Person.builder()
-            .image(image.orElse(null))
-            .voice(voice.orElse(null))
+            .image(image)
+            .voice(voice)
             .name(createPersonReqDto.getName())
             .relation(createPersonReqDto.getRelation())
             .birth(createPersonReqDto.getBirth())

--- a/src/main/java/gdsc/mju/guessme/domain/person/dto/CreatePersonReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/dto/CreatePersonReqDto.java
@@ -14,15 +14,15 @@ import lombok.ToString;
 public class CreatePersonReqDto {
 
 
-    private Optional<String> image;
-    private Optional<String> voice;
+    private String image;
+    private String voice;
     private String name;
     private String relation;
     private LocalDate birth;
     private String residence;
 
     @Builder
-    public CreatePersonReqDto(Optional<String> image, Optional<String> voice, String name, String relation, LocalDate birth, String residence) {
+    public CreatePersonReqDto(String image, String voice, String name, String relation, LocalDate birth, String residence) {
         this.image = image;
         this.voice = voice;
         this.name = name;

--- a/src/main/java/gdsc/mju/guessme/domain/person/dto/CreatePersonReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/dto/CreatePersonReqDto.java
@@ -4,6 +4,7 @@ import gdsc.mju.guessme.domain.info.dto.InfoObj;
 import gdsc.mju.guessme.domain.person.entity.Person;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -12,15 +13,16 @@ import lombok.ToString;
 @ToString
 public class CreatePersonReqDto {
 
-    private String image;
-    private String voice;
+
+    private Optional<String> image;
+    private Optional<String> voice;
     private String name;
     private String relation;
     private LocalDate birth;
     private String residence;
 
     @Builder
-    public CreatePersonReqDto(String image, String voice, String name, String relation, LocalDate birth, String residence) {
+    public CreatePersonReqDto(Optional<String> image, Optional<String> voice, String name, String relation, LocalDate birth, String residence) {
         this.image = image;
         this.voice = voice;
         this.name = name;

--- a/src/main/java/gdsc/mju/guessme/domain/person/entity/Person.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/entity/Person.java
@@ -68,12 +68,25 @@ public class Person {
         this.user = user;
     }
 
+//    public void update(UpdatePersonReqDto updatePersonReqDto) {
+//        this.name = updatePersonReqDto.getName() != null ? updatePersonReqDto.getName() : this.name;
+//        this.relation = updatePersonReqDto.getRelation() != null ? updatePersonReqDto.getRelation() : this.relation;
+//        this.birth = updatePersonReqDto.getBirth() != null ? updatePersonReqDto.getBirth() : this.birth;
+//        this.residence = updatePersonReqDto.getResidence() != null ? updatePersonReqDto.getResidence() : this.residence;
+//        this.image = updatePersonReqDto.getImage() != null ? updatePersonReqDto.getImage() : this.image;
+//        this.voice = updatePersonReqDto.getVoice() != null ? updatePersonReqDto.getVoice() : this.voice;
+//    }
+
     public void update(UpdatePersonReqDto updatePersonReqDto) {
-        this.name = updatePersonReqDto.getName();
-        this.relation = updatePersonReqDto.getRelation();
-        this.birth = updatePersonReqDto.getBirth();
-        this.residence = updatePersonReqDto.getResidence();
-        this.image = updatePersonReqDto.getImage();
-        this.voice = updatePersonReqDto.getVoice();
+        this.name = updateIfNotNull(this.name, updatePersonReqDto.getName());
+        this.relation = updateIfNotNull(this.relation, updatePersonReqDto.getRelation());
+        this.birth = updateIfNotNull(this.birth, updatePersonReqDto.getBirth());
+        this.residence = updateIfNotNull(this.residence, updatePersonReqDto.getResidence());
+        this.image = updateIfNotNull(this.image, updatePersonReqDto.getImage());
+        this.voice = updateIfNotNull(this.voice, updatePersonReqDto.getVoice());
+    }
+
+    private <T> T updateIfNotNull(T property, T value) {
+        return value != null ? value : property;
     }
 }

--- a/src/main/java/gdsc/mju/guessme/domain/person/entity/Person.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/entity/Person.java
@@ -39,7 +39,7 @@ public class Person {
     @Column(nullable = false)
     private String residence;
 
-    @Column(nullable = false)
+    @Column
     private String image;
 
     @Column

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
-#spring.config.import=optional:file:.env[.properties]
-#spring.datasource.url=${LOCAL_DB_URL}
-#spring.datasource.username=${LOCAL_DB_USERNAME}
-#spring.datasource.password=${LOCAL_DB_PASSWORD}
+spring.config.import=optional:file:.env[.properties]
+spring.datasource.url=${LOCAL_DB_URL}
+spring.datasource.username=${LOCAL_DB_USERNAME}
+spring.datasource.password=${LOCAL_DB_PASSWORD}
 #spring.config.import=optional:file:.env.dev[.properties]
-spring.datasource.url=${GCP_DB_URL}
-spring.datasource.username=${GCP_DB_USERNAME}
-spring.datasource.password=${GCP_DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.url=${GCP_DB_URL}
+#spring.datasource.username=${GCP_DB_USERNAME}
+#spring.datasource.password=${GCP_DB_PASSWORD}
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.datasource.hikari.connection-test-query=select 1 from dual
 
 spring.cloud.gcp.credentials.location=classpath:involuted-span-377818-befce0f2e2e3.json

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,15 @@
-spring.config.import=optional:file:.env[.properties]
-spring.datasource.url=${LOCAL_DB_URL}
-spring.datasource.username=${LOCAL_DB_USERNAME}
-spring.datasource.password=${LOCAL_DB_PASSWORD}
+#spring.config.import=optional:file:.env[.properties]
+#spring.datasource.url=${LOCAL_DB_URL}
+#spring.datasource.username=${LOCAL_DB_USERNAME}
+#spring.datasource.password=${LOCAL_DB_PASSWORD}
 #spring.config.import=optional:file:.env.dev[.properties]
-#spring.datasource.url=${GCP_DB_URL}
-#spring.datasource.username=${GCP_DB_USERNAME}
-#spring.datasource.password=${GCP_DB_PASSWORD}
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=${GCP_DB_URL}
+spring.datasource.username=${GCP_DB_USERNAME}
+spring.datasource.password=${GCP_DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.datasource.hikari.connection-test-query=select 1 from dual
+
+spring.cloud.gcp.credentials.location=classpath:involuted-span-377818-befce0f2e2e3.json
 
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
# Person

Closes #18 

| Method                         | URL | Usage                |
| --------------------------- | ------ | -------------------- |
|POST	|/	|인물 추가|
|PATCH|	/{id}	|인물 정보 수정|

위 api의 request body에

image와 voice는 비운 채 인물 추가를 완료하는 경우 또는
인물 수정 시 수정된 값만 넘겨주고 나머지는 null로 채우는 경우와 같은 상황을 고려하여
nullable하게 처리할 수 있도록 했다.

## EX

### 인물 추가 request body

```json
{
    "image": null,
    "voice": null,
    "name": "황보경재니예맞아요",
    "relation": "친구",
    "birth": "2023-01-18T11:22:33",
    "residence": "서울"
}
```

### 인물 수정 request body

```json
{
    "image": null,
    "voice": null,
    "name": null,
    "relation": "손주",
    "birth": "2023-01-19T11:22:33",
    "residence": "용인",
    "info": [
    ]
}
```