### PR TITLE
[Feat] #34 인물 조회 시 인물 id도 함께 반환하도록 함

### DIFF
--- a/src/main/java/gdsc/mju/guessme/domain/person/dto/PersonDetailResDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/dto/PersonDetailResDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 
 @Getter
 public class PersonDetailResDto {
+    private Long id;
     private String name;
     private String relation;
     private LocalDate birth;
@@ -19,8 +20,9 @@ public class PersonDetailResDto {
     private Boolean favorite;
 
     @Builder
-    public PersonDetailResDto(String name, String relation, LocalDate birth, String residence,
+    public PersonDetailResDto(Long id, String name, String relation, LocalDate birth, String residence,
         String image, String voice, List<InfoObj> info, Boolean favorite) {
+        this.id = id;
         this.name = name;
         this.relation = relation;
         this.birth = birth;
@@ -33,6 +35,7 @@ public class PersonDetailResDto {
 
     public static PersonDetailResDto of(Person person, List<InfoObj> info) {
         return PersonDetailResDto.builder()
+            .id(person.getId())
             .name(person.getName())
             .relation(person.getRelation())
             .birth(person.getBirth())


### PR DESCRIPTION
Closes #34 

클라이언트 측 요청 사항 반영을 위한 dto 수정

기능명세서도 수정했습니다! @915dbfl 

### 변경된 Response 객체 예시

```json
{
        "id": 3, // 추가된 데이터
        "name": "김김김",
        "relation": "손자",
        "birth": "2020-01-01",
        "residence": "서울시 금천구",
        "image": "img.url",
        "voice": "voice.url",
        "info": [
            {
                "infoKey": "좋아하는 음식",
                "infoValue": "치킨"
            },
            {
                "infoKey": "좋아하는 색",
                "infoValue": "노란색"
            }
        ],
        "favorite": false
    }
```