### PR TITLE
[Feat] #42 infoObj에 id property 추가

### DIFF
--- a/src/main/java/gdsc/mju/guessme/domain/info/dto/InfoObj.java
+++ b/src/main/java/gdsc/mju/guessme/domain/info/dto/InfoObj.java
@@ -7,18 +7,19 @@ import lombok.Getter;
 
 @Getter
 public class InfoObj {
-
+    private Long id;
     private String infoKey;
     private String infoValue;
 
-    public InfoObj(String infoKey, String infoValue) {
+    public InfoObj(Long id, String infoKey, String infoValue) {
+        this.id = id;
         this.infoKey = infoKey;
         this.infoValue = infoValue;
     }
 
     public static List<InfoObj> of(List<Info> byPerson) {
         return byPerson.stream()
-            .map(info -> new InfoObj(info.getInfoKey(), info.getInfoValue()))
+            .map(info -> new InfoObj(info.getId(), info.getInfoKey(), info.getInfoValue()))
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Closes #42 

정보 데이터에 id를 함께 담기 위해 추가했습니다 @915dbfl 

## 수정 전 res
```json
{
    "status": 200,
    "message": "Load Successfully",
    "data": {
        "id": 5,
        "name": "황보경재니",
        "relation": "지인",
        "birth": "2023-01-19",
        "residence": "서울",
        "image": "https://storage.cloud.google.com/guessme-storage/66717fc4-087b-4d8e-bc93-3ba87aabc530",
        "voice": null,
        "info": [
            {
                "infoKey": "마우스",
                "infoValue": "핸드폰"
            },
            {
                "infoKey": "안경",
                "infoValue": "렌즈"
            }
        ],
        "favorite": false
    }
}
```

## 수정 후 res
```json
{
    "status": 200,
    "message": "Load Successfully",
    "data": {
        ...(생략)
        "info": [
            {
                "id": 22, // 추가!
                "infoKey": "마우스",
                "infoValue": "핸드폰"
            },
            {
                "id": 23,
                "infoKey": "안경",
                "infoValue": "렌즈"
            }
        ],
        "favorite": false
    }
}
```