### PR TITLE
[Feat] #71 #78 chat gpt 적용 및 scoring api 추가 작업

### DIFF
--- a/src/main/java/gdsc/mju/guessme/domain/info/entity/Info.java
+++ b/src/main/java/gdsc/mju/guessme/domain/info/entity/Info.java
@@ -1,10 +1,8 @@
 package gdsc.mju.guessme.domain.info.entity;
 
 import java.time.LocalDateTime;
-import java.util.Set;
 import javax.persistence.*;
 
-import gdsc.mju.guessme.domain.quiz.entity.Scoring;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,9 +39,6 @@ public class Info {
     @ManyToOne(optional = false)
     @JoinColumn(name = "person_id")
     private Person person;
-
-    @OneToMany(mappedBy = "info", cascade = CascadeType.ALL)
-    private Set<Scoring> ScoringList;
 
     @Builder
     public Info(String infoKey, String infoValue, Person person) {

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/QuizController.java
@@ -55,7 +55,7 @@ public class QuizController {
     public BaseResponse<Boolean> scoring(
             @AuthenticationPrincipal UserDetails userDetails,
             @ModelAttribute ScoreReqDto dto // requestBody 대신 @ModelAttribute??
-    ) throws IOException {
+    ) throws IOException, BaseException {
         String username = userDetails.getUsername();
         // dto에 인물id, 인포키, 파일 주소 넣어서 전달
         return new BaseResponse<>(

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/QuizService.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/QuizService.java
@@ -12,6 +12,8 @@ import gdsc.mju.guessme.domain.quiz.dto.ScoreReqDto;
 import gdsc.mju.guessme.domain.user.entity.User;
 import gdsc.mju.guessme.domain.user.repository.UserRepository;
 import gdsc.mju.guessme.global.infra.gcs.GcsService;
+import gdsc.mju.guessme.global.infra.openai.OpenAIService;
+import gdsc.mju.guessme.global.response.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.io.IOException;
@@ -25,6 +27,7 @@ public class QuizService {
     private final UserRepository userRepository;
     private final PersonRepository personRepository;
     private final GcsService gcsService;
+    private final OpenAIService openAIService;
 
 
     public QuizResDto createQuiz(String username, long personId) {
@@ -165,7 +168,7 @@ public class QuizService {
     }
 
 
-    public String findOverlap(String str1, String str2) {
+     private String findOverlap(String str1, String str2) {
         // 더 긴 문자열 str1로 설정
         if (str1.length() < str2.length()) {
             String temp = str1;
@@ -187,5 +190,76 @@ public class QuizService {
         }
 
         return null; // 겹치는 단어가 없을 경우 null 반환
+    }
+
+    private Boolean scoringBirthWithChatGpt(
+            String textFromImage, String answer
+    ) throws BaseException {
+        String prompt = String.format(
+                "The question I just asked was about guessing a birthday, and the correct answer is %s." +
+                "The format of the answer is free because the elderly with dementia are the submitters." +
+                "He submitted \"%s\" If it is correct, please say \"yes,\" otherwise say \"no.\"",
+                answer, textFromImage
+        );
+
+        // return true or false
+        return processResponse(this.openAIService.createCompletion(prompt));
+    }
+
+    private Boolean scoringRelationWithChatGpt(
+            String textFromImage, String answer
+    ) throws BaseException {
+        String prompt = String.format(
+                "The question I just asked was about guessing a relationship, and the correct answer is %s." +
+                "The format of the answer is free because the elderly with dementia are the submitters." +
+                "He submitted \"%s\" If it is correct, please say \"yes,\" otherwise say \"no.\"",
+                answer, textFromImage
+        );
+
+        // return true or false
+        return processResponse(this.openAIService.createCompletion(prompt));
+    }
+
+    private Boolean scoringResidenceWithChatGpt(
+            String textFromImage, String answer
+    ) throws BaseException {
+        String prompt = String.format(
+                "The question I just asked was about guessing a residence, and the correct answer is %s." +
+                "The format of the answer is free because the elderly with dementia are the submitters." +
+                "He submitted \"%s\" If it is correct, please say \"yes,\" otherwise say \"no.\"",
+                answer, textFromImage
+        );
+
+        // return true or false
+        return processResponse(this.openAIService.createCompletion(prompt));
+    }
+
+    private Boolean scoringInfoWithChatGpt(
+            String textFromImage, String question, String answer
+    ) throws BaseException {
+        String prompt = String.format(
+                "The question I just asked was about guessing %s, and the correct answer is %s." +
+                "The format of the answer is free because the elderly with dementia are the submitters." +
+                "He submitted \"%s\" If it is correct, please say \"yes,\" otherwise say \"no.\"",
+                question, answer, textFromImage
+        );
+
+        // return true or false
+        return processResponse(this.openAIService.createCompletion(prompt));
+    }
+
+    private Boolean processResponse(String response) {
+        // Check if the response contains "yes"
+        if (response.contains("yes")) {
+            return true;
+        }
+
+        // Check if the response contains "no"
+        if (response.contains("no")) {
+            return false;
+        }
+
+        // If neither "yes" nor "no" is found, return false as the default value
+        return false;
     }
 }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/dto/ScoreReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/dto/ScoreReqDto.java
@@ -11,7 +11,6 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor
 @ToString
 public class ScoreReqDto {
-    private Long infoId;
     private String infoKey;
     private String infoValue;
     private Long personId;

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/entity/Scoring.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/entity/Scoring.java
@@ -18,12 +18,8 @@ public class Scoring {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
 
-    // 'key'는 mysql의 예약어이므로 쓰면 에러.
     @Column(nullable = false)
-    private Long infoId;
-//    @ManyToOne
-//    @JoinColumn(name = "info_id")
-//    private Info info;
+    private String question;
 
     @Column(nullable = false)
     private Long wrongFlag;
@@ -33,8 +29,8 @@ public class Scoring {
     private Person person;
 
     @Builder
-    public Scoring(Long infoId, Long wrongFlag, Person person) {
-        this.infoId = infoId;
+    public Scoring(String question, Long wrongFlag, Person person) {
+        this.question = question;
         this.wrongFlag = wrongFlag;
         this.person = person;
     }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/repository/ScoringRepository.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/repository/ScoringRepository.java
@@ -5,7 +5,6 @@ import gdsc.mju.guessme.domain.quiz.entity.Scoring;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScoringRepository extends JpaRepository<Scoring, Long> {
-    boolean existsByQuestionAndPerson(String question, Person person);
     Scoring findByQuestionAndPerson(String question, Person person);
     void deleteByQuestionAndPerson(String question, Person person);
 }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/repository/ScoringRepository.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/repository/ScoringRepository.java
@@ -1,10 +1,11 @@
 package gdsc.mju.guessme.domain.quiz.repository;
 
+import gdsc.mju.guessme.domain.person.entity.Person;
 import gdsc.mju.guessme.domain.quiz.entity.Scoring;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScoringRepository extends JpaRepository<Scoring, Long> {
-    boolean existsByInfoId(Long infoId);
-    Scoring findByInfoId(Long infoId);
-    void deleteByInfoId(Long infoId);
+    boolean existsByQuestionAndPerson(String question, Person person);
+    Scoring findByQuestionAndPerson(String question, Person person);
+    void deleteByQuestionAndPerson(String question, Person person);
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIController.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIController.java
@@ -1,0 +1,2 @@
+package gdsc.mju.guessme.global.infra.openai;public class OpenAIController {
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIController.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIController.java
@@ -1,2 +1,0 @@
-package gdsc.mju.guessme.global.infra.openai;public class OpenAIController {
-}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIRestTemplateConfig.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIRestTemplateConfig.java
@@ -1,0 +1,25 @@
+package gdsc.mju.guessme.global.infra.openai;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OpenAIRestTemplateConfig {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Bean
+    @Qualifier("openaiRestTemplate")
+    public RestTemplate openaiRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + openaiApiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
@@ -1,9 +1,7 @@
 package gdsc.mju.guessme.global.infra.openai;
 
-public interface ChatgptService {
+import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
 
-    String sendMessage(String message);
-
-    ChatResponse sendChatRequest(ChatRequest request);
-
+public interface OpenAIService {
+    ChatResponse createCompletion(String prompt);
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
@@ -1,7 +1,8 @@
 package gdsc.mju.guessme.global.infra.openai;
 
 import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
+import gdsc.mju.guessme.global.response.BaseException;
 
 public interface OpenAIService {
-    ChatResponse createCompletion(String prompt);
+    String createCompletion(String prompt) throws BaseException;
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIService.java
@@ -1,0 +1,9 @@
+package gdsc.mju.guessme.global.infra.openai;
+
+public interface ChatgptService {
+
+    String sendMessage(String message);
+
+    ChatResponse sendChatRequest(ChatRequest request);
+
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
@@ -3,6 +3,7 @@ package gdsc.mju.guessme.global.infra.openai;
 import gdsc.mju.guessme.global.infra.openai.dto.ChatRequest;
 import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
 import gdsc.mju.guessme.global.infra.openai.dto.Message;
+import gdsc.mju.guessme.global.response.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,7 +27,7 @@ public class OpenAIServiceImpl implements OpenAIService {
     private String apiUrl;
 
     @Override
-    public ChatResponse createCompletion(String prompt) {
+    public String createCompletion(String prompt) throws BaseException {
         // create a request
         List<Message> messages = List.of(
                 new Message(prompt)
@@ -34,6 +35,12 @@ public class OpenAIServiceImpl implements OpenAIService {
         ChatRequest request = new ChatRequest(model, messages, 0.9);
 
         // call the API
-        return restTemplate.postForObject(apiUrl, request, ChatResponse.class);
+        ChatResponse chatResponse = restTemplate.postForObject(apiUrl, request, ChatResponse.class);
+        if(chatResponse == null) {
+            throw new BaseException(500, "OpenAI API call failed");
+        }
+
+        // return the response
+        return chatResponse.getChoices().get(0).getMessage().getContent();
     }
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
@@ -1,5 +1,8 @@
 package gdsc.mju.guessme.global.infra.openai;
 
+import gdsc.mju.guessme.global.infra.openai.dto.ChatRequest;
+import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
+import gdsc.mju.guessme.global.infra.openai.dto.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -7,9 +10,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
-public class ChatgptServiceImpl implements ChatgptService {
+public class OpenAIServiceImpl implements OpenAIService {
     @Qualifier("openaiRestTemplate")
     @Autowired
     private final RestTemplate restTemplate;
@@ -21,37 +26,14 @@ public class ChatgptServiceImpl implements ChatgptService {
     private String apiUrl;
 
     @Override
-    public String sendMessage(String message) {
-        return null;
-    }
+    public ChatResponse createCompletion(String prompt) {
+        // create a request
+        List<Message> messages = List.of(
+                new Message(prompt)
+        );
+        ChatRequest request = new ChatRequest(model, messages, 0.9);
 
-    @Override
-    public ChatResponse sendChatRequest(ChatRequest request) {
-        return null;
-    }
-
-    @Override
-    public String multiChat(List<MultiChatMessage> messages) {
-        return null;
-    }
-
-    @Override
-    public MultiChatResponse multiChatRequest(MultiChatRequest multiChatRequest) {
-        return null;
-    }
-
-    @Override
-    public String imageGenerate(String prompt) {
-        return null;
-    }
-
-    @Override
-    public List<String> imageGenerate(String prompt, Integer n, ImageSize size, ImageFormat format) {
-        return null;
-    }
-
-    @Override
-    public ImageResponse imageGenerateRequest(ImageRequest imageRequest) {
-        return null;
+        // call the API
+        return restTemplate.postForObject(apiUrl, request, ChatResponse.class);
     }
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImpl.java
@@ -1,0 +1,57 @@
+package gdsc.mju.guessme.global.infra.openai;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@Service
+public class ChatgptServiceImpl implements ChatgptService {
+    @Qualifier("openaiRestTemplate")
+    @Autowired
+    private final RestTemplate restTemplate;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Override
+    public String sendMessage(String message) {
+        return null;
+    }
+
+    @Override
+    public ChatResponse sendChatRequest(ChatRequest request) {
+        return null;
+    }
+
+    @Override
+    public String multiChat(List<MultiChatMessage> messages) {
+        return null;
+    }
+
+    @Override
+    public MultiChatResponse multiChatRequest(MultiChatRequest multiChatRequest) {
+        return null;
+    }
+
+    @Override
+    public String imageGenerate(String prompt) {
+        return null;
+    }
+
+    @Override
+    public List<String> imageGenerate(String prompt, Integer n, ImageSize size, ImageFormat format) {
+        return null;
+    }
+
+    @Override
+    public ImageResponse imageGenerateRequest(ImageRequest imageRequest) {
+        return null;
+    }
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/ChatRequest.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/ChatRequest.java
@@ -1,0 +1,22 @@
+package gdsc.mju.guessme.global.infra.openai.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ChatRequest {
+    private String model;
+
+    private List<Message> messages;
+
+    private Double temperature;
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/ChatResponse.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/ChatResponse.java
@@ -1,0 +1,17 @@
+package gdsc.mju.guessme.global.infra.openai.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class ChatResponse {
+    private String id;
+    private String object;
+    private LocalDate created;
+    private String model;
+    private List<Choice> choices;
+    private Usage usage;
+
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Choice.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Choice.java
@@ -1,0 +1,16 @@
+package gdsc.mju.guessme.global.infra.openai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Choice {
+    private Message message;
+    private String text;
+    private Integer index;
+    private String logprobs;
+
+    @JsonProperty("finish_reason")
+    private String finishReason;
+
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Message.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Message.java
@@ -1,2 +1,16 @@
-package gdsc.mju.guessme.global.infra.openai.dto;public class Message {
+package gdsc.mju.guessme.global.infra.openai.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+
+    public Message(String content) {
+        this.role = "user";
+        this.content = content;
+    }
 }

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Message.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Message.java
@@ -1,0 +1,2 @@
+package gdsc.mju.guessme.global.infra.openai.dto;public class Message {
+}

--- a/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Usage.java
+++ b/src/main/java/gdsc/mju/guessme/global/infra/openai/dto/Usage.java
@@ -1,0 +1,17 @@
+package gdsc.mju.guessme.global.infra.openai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Usage {
+    @JsonProperty("prompt_tokens")
+    private Integer promptTokens;
+
+    @JsonProperty("completion_tokens")
+    private Integer completionTokens;
+
+    @JsonProperty("total_tokens")
+    private Integer totalTokens;
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
-#spring.config.import=optional:file:.env[.properties]
-#spring.datasource.url=${LOCAL_DB_URL}
-#spring.datasource.username=${LOCAL_DB_USERNAME}
-#spring.datasource.password=${LOCAL_DB_PASSWORD}
+spring.config.import=optional:file:.env[.properties]
+spring.datasource.url=${LOCAL_DB_URL}
+spring.datasource.username=${LOCAL_DB_USERNAME}
+spring.datasource.password=${LOCAL_DB_PASSWORD}
 
-spring.config.import=optional:file:.env.dev[.properties]
-spring.datasource.url=${GCP_DB_URL}
-spring.datasource.username=${GCP_DB_USERNAME}
-spring.datasource.password=${GCP_DB_PASSWORD}
+#spring.config.import=optional:file:.env.dev[.properties]
+#spring.datasource.url=${GCP_DB_URL}
+#spring.datasource.username=${GCP_DB_USERNAME}
+#spring.datasource.password=${GCP_DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.connection-test-query=select 1 from dual
 
@@ -14,6 +14,10 @@ spring.cloud.gcp.credentials.location=classpath:involuted-span-377818-befce0f2e2
 spring.cloud.gcp.storage.credentials.location=classpath:involuted-span-377818-a3d393cddc53.json
 spring.cloud.gcp.storage.project-id=${GCP_PROJECT_ID}
 spring.cloud.gcp.storage.bucket=${GCP_STORAGE_BUCKET}
+
+openai.model=gpt-3.5-turbo
+openai.api.url=https://api.openai.com/v1/chat/completions
+openai.api.key=${OPENAI_API_KEY}
 
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/src/test/java/gdsc/mju/guessme/domain/quiz/QuizServiceTest.java
+++ b/src/test/java/gdsc/mju/guessme/domain/quiz/QuizServiceTest.java
@@ -15,21 +15,21 @@ class QuizServiceTest {
     @Autowired
     private QuizService quizService;
 
-    @Test
-    void scoringMethodForTest() throws BaseException, IOException {
-        String username = "hou27";
-        String infoKey = "name";
-        String infoValue = "newname";
-        Long personId = 1L;
-        String textFromImage = "newname";
-
-        Boolean result = quizService.scoringMethodForTest(username, infoKey, infoValue, personId, textFromImage);
-
-        assertEquals(true, result);
-    }
-
-    @Test
-    void sendEmailForTest() {
-        quizService.sendEmailForTest("ataj125@gmail.com");
-    }
+//    @Test
+//    void scoringMethodForTest() throws BaseException, IOException {
+//        String username = "hou27";
+//        String infoKey = "name";
+//        String infoValue = "newname";
+//        Long personId = 1L;
+//        String textFromImage = "newname";
+//
+//        Boolean result = quizService.scoringMethodForTest(username, infoKey, infoValue, personId, textFromImage);
+//
+//        assertEquals(true, result);
+//    }
+//
+//    @Test
+//    void sendEmailForTest() {
+//        quizService.sendEmailForTest("ataj125@gmail.com");
+//    }
 }

--- a/src/test/java/gdsc/mju/guessme/domain/quiz/QuizServiceTest.java
+++ b/src/test/java/gdsc/mju/guessme/domain/quiz/QuizServiceTest.java
@@ -1,0 +1,35 @@
+package gdsc.mju.guessme.domain.quiz;
+
+
+import gdsc.mju.guessme.global.response.BaseException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class QuizServiceTest {
+    @Autowired
+    private QuizService quizService;
+
+    @Test
+    void scoringMethodForTest() throws BaseException, IOException {
+        String username = "hou27";
+        String infoKey = "name";
+        String infoValue = "newname";
+        Long personId = 1L;
+        String textFromImage = "newname";
+
+        Boolean result = quizService.scoringMethodForTest(username, infoKey, infoValue, personId, textFromImage);
+
+        assertEquals(true, result);
+    }
+
+    @Test
+    void sendEmailForTest() {
+        quizService.sendEmailForTest("ataj125@gmail.com");
+    }
+}

--- a/src/test/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImplTest.java
+++ b/src/test/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImplTest.java
@@ -1,0 +1,24 @@
+package gdsc.mju.guessme.global.infra.openai;
+
+import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class OpenAIServiceImplTest {
+    @Autowired
+    private OpenAIService openAIService;
+
+    @Test
+    void createCompletion() {
+        String prompt = "Say Hi";
+        ChatResponse result = openAIService.createCompletion(prompt);
+        System.out.println(result);
+
+        // check if is existed
+        assertNotNull(result.getChoices().get(0).getMessage().getContent());
+    }
+}

--- a/src/test/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImplTest.java
+++ b/src/test/java/gdsc/mju/guessme/global/infra/openai/OpenAIServiceImplTest.java
@@ -1,6 +1,6 @@
 package gdsc.mju.guessme.global.infra.openai;
 
-import gdsc.mju.guessme.global.infra.openai.dto.ChatResponse;
+import gdsc.mju.guessme.global.response.BaseException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,12 +13,12 @@ class OpenAIServiceImplTest {
     private OpenAIService openAIService;
 
     @Test
-    void createCompletion() {
+    void createCompletion() throws BaseException {
         String prompt = "Say Hi";
-        ChatResponse result = openAIService.createCompletion(prompt);
+        String result = openAIService.createCompletion(prompt);
         System.out.println(result);
 
         // check if is existed
-        assertNotNull(result.getChoices().get(0).getMessage().getContent());
+        assertNotNull(result);
     }
 }


### PR DESCRIPTION
# 정답 채점 과정에 chat gpt 적용 및 추가 반영 사항 작업

#71 작업 내용 포함

정답을 채점하는 과정에 chat api를 도입하여 보다 폭넓은 정답 처리를 제공하고자 한다.
[Using OpenAI in Spring Boot](https://www.baeldung.com/spring-boot-chatgpt-api-openai)
[OpenAI Doc](https://platform.openai.com/docs/api-reference/chat/create)

- chat gpt api key 발급
- api 연동
- 각 문제에 맞는 프롬프트 작성
    - 이름
    - 주소
    - 관계
    - 생년월일
    - 추가 infos

- [ScoreReqDto 수정](https://github.com/GUESS-ME-GDSC/Server/commit/7c5b4d120169d66eebc00b0cd795c4bce87bafcc)

#78 작업
- 프롬프트 메서드 적용
- scoring repository 메서드 수정
- Test

Closes #71, Closes #78 