### PR TITLE
[!HOTFIX] #80 info 수정 요청 시 발생하는 에러 수정

### DIFF
--- a/src/main/java/gdsc/mju/guessme/domain/info/dto/InfoObj.java
+++ b/src/main/java/gdsc/mju/guessme/domain/info/dto/InfoObj.java
@@ -4,8 +4,11 @@ import gdsc.mju.guessme.domain.info.entity.Info;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Getter
+@Getter @Setter
+@NoArgsConstructor
 public class InfoObj {
     private Long id;
     private String infoKey;

--- a/src/main/java/gdsc/mju/guessme/domain/person/dto/UpdatePersonReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/person/dto/UpdatePersonReqDto.java
@@ -3,13 +3,12 @@ package gdsc.mju.guessme.domain.person.dto;
 import gdsc.mju.guessme.domain.info.dto.InfoObj;
 import java.time.LocalDate;
 import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
-@Getter
+@Getter @Setter
 @ToString
 public class UpdatePersonReqDto {
 
@@ -23,7 +22,15 @@ public class UpdatePersonReqDto {
     private List<InfoObj> info;
 
     @Builder
-    public UpdatePersonReqDto(MultipartFile image, MultipartFile voice, String name, String relation, LocalDate birth, String residence, List<InfoObj> info) {
+    public UpdatePersonReqDto(
+            MultipartFile image,
+            MultipartFile voice,
+            String name,
+            String relation,
+            LocalDate birth,
+            String residence,
+            List<InfoObj> info
+    ) {
         this.image = image;
         this.voice = voice;
         this.name = name;


### PR DESCRIPTION
<img width="600" alt="KakaoTalk_Photo_2023-05-21-16-23-05" src="https://github.com/GUESS-ME-GDSC/Server/assets/65845941/038c0b13-4714-4d51-ad50-71b26c44fa9e">

1. Invalid property ' ' of bean class 에러
객체를 생성 후 값 주입에서 에러가 발생.
setter 추가
https://darmk.tistory.com/entry/Invalid-property-of-bean-class-에러

2. dto 빈 생성자 추가
https://azurealstn.tistory.com/74\

### 작업 내용
- UpdatePersonReqDto에 Setter 추가
- InfoObj에 Setter, 기본 생성자 추가

Closes #80 