### PR TITLE
[Feat] #86 유사도 기준보다 떨어질 시 메일 전송

### DIFF
--- a/src/main/java/gdsc/mju/guessme/domain/auth/dto/AuthReqDto.java
+++ b/src/main/java/gdsc/mju/guessme/domain/auth/dto/AuthReqDto.java
@@ -2,10 +2,12 @@ package gdsc.mju.guessme.domain.auth.dto;
 
 import gdsc.mju.guessme.domain.user.entity.User;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor
 public class AuthReqDto {
     private String userId;
     private String userPassword;
@@ -19,9 +21,9 @@ public class AuthReqDto {
 
     public User toUserEntity() {
         return User.builder()
-            .userId(userId)
-            .userPassword(userPassword)
-            .email(email)
-            .build();
+                .userId(userId)
+                .userPassword(userPassword)
+                .email(email)
+                .build();
     }
 }

--- a/src/main/java/gdsc/mju/guessme/domain/quiz/entity/Scoring.java
+++ b/src/main/java/gdsc/mju/guessme/domain/quiz/entity/Scoring.java
@@ -1,15 +1,19 @@
 package gdsc.mju.guessme.domain.quiz.entity;
 
-import gdsc.mju.guessme.domain.info.entity.Info;
 import gdsc.mju.guessme.domain.person.entity.Person;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
 @Entity
 public class Scoring {
@@ -18,6 +22,11 @@ public class Scoring {
     @Column(name = "id")
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime correctAt;
 
     @Column(nullable = false)
     private String question;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,6 @@ spring.thymeleaf.suffix=.html
 spring.thymeleaf.mode=HTML5
 spring.thymeleaf.cache=false
 spring.thymeleaf.order=0
+
+spring.servlet.multipart.maxFileSize=10MB
+spring.servlet.multipart.maxRequestSize=10MB

--- a/src/main/resources/templates/mailForHandwritingDissimilarity.html
+++ b/src/main/resources/templates/mailForHandwritingDissimilarity.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Fly Away Registration Email</title>
+</head>
+<style>
+    body {
+        text-align: center;
+    }
+    img {
+        max-width: 100%;
+        height: auto;
+    }
+</style>
+<body>
+<table style="width:100%; height:100%;">
+    <tr>
+        <td align="center" valign="middle">
+            <div>
+                <h1> 👀 Guess me! </h1>
+                <img th:src="${firstImage}" width="400" height="100"> </br>
+                <p style="margin-top: 10px;"><h3>written date : [[${firstImageTime}]]</h3></p>
+                <img th:src="${lastImage}" width="400" height="100"> </br>
+                <p style="margin-top: 10px;"><h3>written date : [[${lastImageTime}]]</h3></p>
+                <p style="margin-top: 10px;"><h3>The similarity between the initial handwriting and current handwriting is low. You may need to consult your loved one's doctor.</h3></p>
+            </div>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
- 첨부 이미지 용량 제한 증가
- scoring 테이블에 correct_at 속성 추가함. -> 처음 정답 맞췄을 때 시간
- 유사도 기준보다 떨어질 시 메일 전송 (2.0 이상일 시 메일 전송)
- 메일에 첫 이미지, 첫 이미지 촬영 시간,  유사도 낮은 이미지, 유사도 낮은 이미지 촬영 시간 포함
- 유사도 낮은 이미지는 따로 테이블에 저장하지 않고 url 추출 후 바로 메일에 첨부하면 됨.
![image](https://github.com/GUESS-ME-GDSC/Server/assets/86697585/22cd152e-7e6f-4f08-8804-e9d9c27cd119)

Close #86, #88